### PR TITLE
Fixed platform collision and jumping

### DIFF
--- a/Assets/Scenes/Level/Assets/Falling Platform.prefab
+++ b/Assets/Scenes/Level/Assets/Falling Platform.prefab
@@ -148,7 +148,7 @@ PlatformEffector2D:
     serializedVersion: 2
     m_Bits: 4294967295
   m_RotationalOffset: 0
-  m_UseOneWay: 1
+  m_UseOneWay: 0
   m_UseOneWayGrouping: 0
   m_SurfaceArc: 180
   m_UseSideFriction: 0

--- a/Assets/Scenes/Level/Level One.unity
+++ b/Assets/Scenes/Level/Level One.unity
@@ -167,6 +167,95 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &62119671
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2616603906367836152, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_Name
+      value: Falling Platform (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2616603906367836152, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4633071876590238262, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: Priority
+      value: 122
+      objectReference: {fileID: 0}
+    - target: {fileID: 4633071876590238262, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_Volume
+      value: 0.574
+      objectReference: {fileID: 0}
+    - target: {fileID: 4633071876590238262, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: rolloffMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4633071876590238262, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: panLevelCustomCurve.m_Curve.Array.data[0].value
+      value: 0.184
+      objectReference: {fileID: 0}
+    - target: {fileID: 4633071876590238262, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: reverbZoneMixCustomCurve.m_Curve.Array.data[0].value
+      value: 0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.58
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6660222867768962840, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_UseOneWay
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6660222867768962840, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
+      propertyPath: m_UseOneWayGrouping
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
 --- !u!1001 &237425927
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1013,63 +1102,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &808642442
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2616603906367836152, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_Name
-      value: Falling Platform (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4.36
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.88
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5633370970798967701, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d9b3daefcfa23984390d5c80afa0a851, type: 3}
 --- !u!1 &850216886
 GameObject:
   m_ObjectHideFlags: 0
@@ -2634,9 +2666,9 @@ SceneRoots:
   - {fileID: 411240289}
   - {fileID: 8620188196195741460}
   - {fileID: 1440373223146336983}
+  - {fileID: 62119671}
   - {fileID: 4503677252559733366}
   - {fileID: 2410461320132221854}
   - {fileID: 1190920068}
-  - {fileID: 808642442}
   - {fileID: 374585841}
   - {fileID: 457440639}

--- a/Assets/Scenes/Level/Scripts/PlayerController.cs
+++ b/Assets/Scenes/Level/Scripts/PlayerController.cs
@@ -12,6 +12,7 @@ public class PlayerController : MonoBehaviour
     private bool grounded;
     private float jumpDelay;
     private float moveDelay;
+    private float jumpCounter;
 
     private GameObject ui_scoreObj;
     private uiScoreAudio uiScoreScript;
@@ -128,7 +129,7 @@ public class PlayerController : MonoBehaviour
             body.velocity = new Vector2(body.velocity.x, jumpForce);
             playerAudioScript.jumpAudio();
             grounded = false;
-            StartCoroutine("Delay");
+            //StartCoroutine("Delay");
         }
     }
 


### PR DESCRIPTION
Didn't do anything with the escape key since it is already in here, but changed the collision for the platform.  Jumping can only happen now when you are grounded (no more double jump or holding down to "fly".